### PR TITLE
[Update cipher.rb] Access key length by .value.length as getLength is not exposed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.3
+  - [Update cipher.rb] Access key length by .value.length as getLength is not exposed. [#33](https://api.github.com/repos/logstash-plugins/logstash-filter-cipher/pulls/33)
+
 ## 4.0.2
   - [DOC] Fixes "Note" formatting for the Key setting [#30](https://github.com/logstash-plugins/logstash-filter-cipher/pull/30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.0.3
-  - [Update cipher.rb] Access key length by .value.length as getLength is not exposed. [#33](https://github.com/logstash-plugins/logstash-filter-cipher/pull/33)
+  - Fix: Debug statement doesn't use .value fetch key's value [#33](https://github.com/logstash-plugins/logstash-filter-cipher/pull/33)
 
 ## 4.0.2
   - [DOC] Fixes "Note" formatting for the Key setting [#30](https://github.com/logstash-plugins/logstash-filter-cipher/pull/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.0.3
-  - [Update cipher.rb] Access key length by .value.length as getLength is not exposed. [#33](https://api.github.com/repos/logstash-plugins/logstash-filter-cipher/pulls/33)
+  - [Update cipher.rb] Access key length by .value.length as getLength is not exposed. [#33](https://github.com/logstash-plugins/logstash-filter-cipher/pull/33)
 
 ## 4.0.2
   - [DOC] Fixes "Note" formatting for the Key setting [#30](https://github.com/logstash-plugins/logstash-filter-cipher/pull/30)

--- a/lib/logstash/filters/cipher.rb
+++ b/lib/logstash/filters/cipher.rb
@@ -122,7 +122,7 @@ class LogStash::Filters::Cipher < LogStash::Filters::Base
     end
 
     if @key.value.length != @key_size
-      @logger.debug("key length is " + @key.length.to_s + ", padding it to " + @key_size.to_s + " with '" + @key_pad.to_s + "'")
+      @logger.debug("key length is " + @key.value.length.to_s + ", padding it to " + @key_size.to_s + " with '" + @key_pad.to_s + "'")
       @key = @key.class.new(@key.value[0,@key_size].ljust(@key_size,@key_pad))
     end
   end # def register

--- a/logstash-filter-cipher.gemspec
+++ b/logstash-filter-cipher.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-cipher'
-  s.version         = '4.0.2'
+  s.version         = '4.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Applies or removes a cipher to an event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
https://github.com/elastic/logstash/blob/main/logstash-core/src/main/java/co/elastic/logstash/api/Password.java does not expose `getLength`, we need to use `.value`

**Context**: User got the error below while running Logstash with `cipher` filter plugin used in the pipeline.

```
[ERROR][logstash.javapipeline ][main] Pipeline error {:pipeline_id=>"REDACTED", :exception=>#<NoMethodError: undefined method `length' for <password>:Java::CoElasticLogstashApi::Password>, :backtrace=>["/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-filter-cipher-4.0.2/lib/logstash/filters/cipher.rb:125:in `register'", "org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java:75:in `register'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:232:in `block in register_plugins'", "org/jruby/RubyArray.java:1821:in `each'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:231:in `register_plugins'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:594:in `maybe_setup_out_plugins'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:244:in `start_workers'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:189:in `run'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:141:in `block in start'"], "pipeline.sources"=>["REDACTED"], :thread=>"#<Thread:REDACTED run>"}
```

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
